### PR TITLE
Replace Moq with NSubstitute

### DIFF
--- a/Src/Nemcache.Client/Properties/packages.config
+++ b/Src/Nemcache.Client/Properties/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Moq" version="4.0.10827" targetFramework="net45" />
   <package id="Rx-Core" version="2.1.30214.0" targetFramework="net45" />
   <package id="Rx-Interfaces" version="2.1.30214.0" targetFramework="net45" />
   <package id="Rx-Linq" version="2.1.30214.0" targetFramework="net45" />

--- a/Src/Nemcache.Tests/Nemcache.Tests.csproj
+++ b/Src/Nemcache.Tests/Nemcache.Tests.csproj
@@ -38,8 +38,8 @@
     <Reference Include="Microsoft.Reactive.Testing">
       <HintPath>..\packages\Rx-Testing.2.1.30214.0\lib\Net45-Full\Microsoft.Reactive.Testing.dll</HintPath>
     </Reference>
-    <Reference Include="Moq">
-      <HintPath>..\packages\Moq.4.0.10827\lib\NET40\Moq.dll</HintPath>
+    <Reference Include="NSubstitute">
+      <HintPath>..\packages\NSubstitute.1.4.3\lib\NET40\NSubstitute.dll</HintPath>
     </Reference>
     <Reference Include="protobuf-net, Version=2.0.0.621, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/Src/Nemcache.Tests/Persistence/StreamArchiverTests.cs
+++ b/Src/Nemcache.Tests/Persistence/StreamArchiverTests.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Moq;
+using NSubstitute;
 using Nemcache.Service;
 using Nemcache.Service.IO;
 using Nemcache.Service.Persistence;
@@ -15,28 +15,26 @@ namespace Nemcache.Tests.Persistence
     {
         private MemCache _originalCache;
         private StreamArchiver _streamArchiver;
-        private Mock<IFile> _mockFile;
+        private IFile _mockFile;
         private MemoryStream _writeStream;
-        private Mock<IFileSystem> _mockFileSystem;
+        private IFileSystem _mockFileSystem;
 
         [TestInitialize]
         public void Setup()
         {
             // TODO: test the archiver without a cache
             _originalCache = new MemCache(1000);
-            _mockFile = new Mock<IFile>();
+            _mockFile = Substitute.For<IFile>();
 
             _writeStream = new MemoryStream();
-            _mockFile.Setup(s => s.Open(
-                It.IsAny<string>(),
-                It.Is<FileMode>(fm => fm == FileMode.OpenOrCreate),
-                It.Is<FileAccess>(fa => fa == FileAccess.Write))).Returns(_writeStream);
+            _mockFile.Open(Arg.Any<string>(), FileMode.OpenOrCreate, FileAccess.Write)
+                     .Returns(_writeStream);
 
-            _mockFileSystem = new Mock<IFileSystem>();
-            _mockFileSystem.SetupGet(fs => fs.File).Returns(_mockFile.Object);
+            _mockFileSystem = Substitute.For<IFileSystem>();
+            _mockFileSystem.File.Returns(_mockFile);
 
 
-            _streamArchiver = new StreamArchiver(_mockFileSystem.Object, "path", _originalCache, 1000);
+            _streamArchiver = new StreamArchiver(_mockFileSystem, "path", _originalCache, 1000);
             _originalCache.Notifications.Subscribe(_streamArchiver);
         }
 

--- a/Src/Nemcache.Tests/packages.config
+++ b/Src/Nemcache.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Moq" version="4.0.10827" targetFramework="net45" />
+  <package id="NSubstitute" version="1.4.3" targetFramework="net45" />
   <package id="Rx-Core" version="2.1.30214.0" targetFramework="net45" />
   <package id="Rx-Interfaces" version="2.1.30214.0" targetFramework="net45" />
   <package id="Rx-Linq" version="2.1.30214.0" targetFramework="net45" />


### PR DESCRIPTION
## Summary
- remove Moq package references
- add NSubstitute references
- update unit tests to use NSubstitute

## Testing
- `dotnet test Src/Nemcache.sln` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_684016944ccc83278a3692aa8ac32042