### PR TITLE
Add hybrid log store example

### DIFF
--- a/Src/Nemcache.Service/Persistence/HybridLogStore.cs
+++ b/Src/Nemcache.Service/Persistence/HybridLogStore.cs
@@ -1,0 +1,168 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Nemcache.Service.IO;
+
+namespace Nemcache.Service.Persistence
+{
+    /// <summary>
+    /// Simplified hybrid log store inspired by Microsoft's FASTER.
+    /// New updates are buffered in memory and periodically flushed to a
+    /// single append-only log file on disk. An in-memory index maps keys
+    /// to offsets either in the memory buffer or the persisted log.
+    /// </summary>
+    internal class HybridLogStore : IDisposable
+    {
+        private readonly IFileSystem _fileSystem;
+        private readonly string _logPath;
+        private readonly long _memoryLimit;
+        private MemoryStream _memLog = new();
+        private FileStream? _logFile;
+
+        private struct Entry
+        {
+            public bool InMemory;
+            public long Offset;
+            public int Length;
+        }
+
+        private readonly Dictionary<string, Entry> _index = new();
+        public IEnumerable<string> Keys => _index.Keys;
+
+        public HybridLogStore(IFileSystem fileSystem, string path, long memoryLimit)
+        {
+            _fileSystem = fileSystem;
+            _logPath = path;
+            _memoryLimit = memoryLimit;
+            var directory = Path.GetDirectoryName(path) ?? ".";
+            Directory.CreateDirectory(directory);
+            LoadIndex();
+        }
+
+        public void Put(string key, byte[] value)
+        {
+            var offset = _memLog.Position;
+            WriteEntry(_memLog, key, value);
+            _index[key] = new Entry { InMemory = true, Offset = offset, Length = value.Length };
+            if (_memLog.Length >= _memoryLimit)
+                Flush();
+        }
+
+        public bool TryGet(string key, out byte[]? value)
+        {
+            value = null;
+            if (!_index.TryGetValue(key, out var entry))
+                return false;
+
+            if (entry.InMemory)
+            {
+                _memLog.Position = entry.Offset;
+                value = ReadEntry(_memLog).value;
+                return true;
+            }
+
+            using var stream = _fileSystem.File.Open(_logPath, FileMode.OpenOrCreate, FileAccess.Read) as FileStream;
+            stream!.Seek(entry.Offset, SeekOrigin.Begin);
+            value = ReadEntry(stream).value;
+            return true;
+        }
+
+        public void Delete(string key)
+        {
+            _index.Remove(key);
+            WriteEntry(_memLog, key, Array.Empty<byte>()); // tombstone
+            if (_memLog.Length >= _memoryLimit)
+                Flush();
+        }
+
+        public IEnumerable<KeyValuePair<string, byte[]>> Entries()
+        {
+            foreach (var key in _index.Keys)
+                if (TryGet(key, out var val) && val != null && val.Length > 0)
+                    yield return new KeyValuePair<string, byte[]>(key, val);
+        }
+
+        private void EnsureFile()
+        {
+            if (_logFile == null)
+            {
+                _logFile = _fileSystem.File.Open(_logPath, FileMode.OpenOrCreate, FileAccess.Write) as FileStream;
+                _logFile.Seek(0, SeekOrigin.End);
+            }
+        }
+
+        private void Flush()
+        {
+            if (_memLog.Length == 0)
+                return;
+
+            EnsureFile();
+            var baseOffset = _logFile!.Length;
+            _memLog.Position = 0;
+            _memLog.CopyTo(_logFile);
+            _logFile.Flush();
+
+            foreach (var key in _index.Keys.ToList())
+            {
+                var entry = _index[key];
+                if (entry.InMemory)
+                {
+                    entry.InMemory = false;
+                    entry.Offset = baseOffset + entry.Offset;
+                    _index[key] = entry;
+                }
+            }
+
+            _memLog.Dispose();
+            _memLog = new MemoryStream();
+        }
+
+        private static void WriteEntry(Stream stream, string key, byte[] value)
+        {
+            var keyBytes = System.Text.Encoding.UTF8.GetBytes(key);
+            var header = BitConverter.GetBytes(keyBytes.Length)
+                .Concat(BitConverter.GetBytes(value.Length)).ToArray();
+            stream.Write(header, 0, header.Length);
+            stream.Write(keyBytes, 0, keyBytes.Length);
+            stream.Write(value, 0, value.Length);
+        }
+
+        private static (string key, byte[] value) ReadEntry(Stream stream)
+        {
+            Span<byte> header = stackalloc byte[8];
+            stream.Read(header);
+            var keyLen = BitConverter.ToInt32(header.Slice(0, 4));
+            var valLen = BitConverter.ToInt32(header.Slice(4, 4));
+            var keyBytes = new byte[keyLen];
+            stream.Read(keyBytes, 0, keyLen);
+            var valBytes = new byte[valLen];
+            stream.Read(valBytes, 0, valLen);
+            return (System.Text.Encoding.UTF8.GetString(keyBytes), valBytes);
+        }
+
+        private void LoadIndex()
+        {
+            if (!_fileSystem.File.Exists(_logPath))
+                return;
+
+            using var stream = _fileSystem.File.Open(_logPath, FileMode.OpenOrCreate, FileAccess.Read) as FileStream;
+            while (stream!.Position < stream.Length)
+            {
+                var offset = stream.Position;
+                var entry = ReadEntry(stream);
+                if (entry.value.Length == 0)
+                    _index.Remove(entry.key);
+                else
+                    _index[entry.key] = new Entry { InMemory = false, Offset = offset, Length = entry.value.Length };
+            }
+        }
+
+        public void Dispose()
+        {
+            Flush();
+            _logFile?.Dispose();
+            _memLog.Dispose();
+        }
+    }
+}

--- a/Src/Nemcache.Tests/Persistence/HybridLogStoreTests.cs
+++ b/Src/Nemcache.Tests/Persistence/HybridLogStoreTests.cs
@@ -1,0 +1,87 @@
+using System;
+using System.IO;
+using NUnit.Framework;
+using Nemcache.Service.IO;
+using Nemcache.Service.Persistence;
+
+namespace Nemcache.Tests.Persistence
+{
+    [TestFixture]
+    public class HybridLogStoreTests
+    {
+        private string _dir = null!;
+        private IFileSystem _fs = null!;
+
+        private class SharedFileSystem : IFileSystem, IFile
+        {
+            public IFile File => this;
+            public Stream Open(string path, FileMode mode, FileAccess access) => new FileStream(path, mode, access, FileShare.ReadWrite);
+            public bool Exists(string path) => File.Exists(path);
+            public long Size(string filename) => new FileInfo(filename).Length;
+            public void Delete(string path) => File.Delete(path);
+            public void Replace(string sourceFileName, string destinationFileName, string destinationBackupFileName, bool ignoreMetadataErrors)
+                => File.Replace(sourceFileName, destinationFileName, destinationBackupFileName, ignoreMetadataErrors);
+        }
+
+        [SetUp]
+        public void Setup()
+        {
+            _dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(_dir);
+            _fs = new SharedFileSystem();
+        }
+
+        [TearDown]
+        public void Cleanup()
+        {
+            if (Directory.Exists(_dir))
+                Directory.Delete(_dir, true);
+        }
+
+        [Test]
+        public void PutAndGetRoundtrip()
+        {
+            var path = Path.Combine(_dir, "log.dat");
+            using (var store = new HybridLogStore(_fs, path, 1024))
+            {
+                store.Put("k", new byte[] {1,2,3});
+                Assert.IsTrue(store.TryGet("k", out var val));
+                CollectionAssert.AreEqual(new byte[] {1,2,3}, val);
+            }
+
+            using (var store = new HybridLogStore(_fs, path, 1024))
+            {
+                Assert.IsTrue(store.TryGet("k", out var value));
+                CollectionAssert.AreEqual(new byte[] {1,2,3}, value);
+            }
+        }
+
+        [Test]
+        public void FlushesToDiskWhenLimitExceeded()
+        {
+            var path = Path.Combine(_dir, "log.dat");
+            using (var store = new HybridLogStore(_fs, path, 10))
+            {
+                store.Put("a", new byte[] {4,5,6,7,8,9}); // exceed limit
+            }
+
+            using (var store = new HybridLogStore(_fs, path, 10))
+            {
+                Assert.IsTrue(store.TryGet("a", out var value));
+                CollectionAssert.AreEqual(new byte[] {4,5,6,7,8,9}, value);
+            }
+        }
+
+        [Test]
+        public void DeleteRemovesItem()
+        {
+            var path = Path.Combine(_dir, "log.dat");
+            using (var store = new HybridLogStore(_fs, path, 100))
+            {
+                store.Put("z", new byte[] {9});
+                store.Delete("z");
+                Assert.IsFalse(store.TryGet("z", out _));
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement a simple `HybridLogStore` that buffers writes in memory and flushes to an on-disk log
- add `HybridLogStoreTests` verifying basic operations

## Testing
- `dotnet test Src/Nemcache.Tests/Nemcache.Tests.csproj --no-build --configuration Release` *(fails: Test host process crashed)*

------
https://chatgpt.com/codex/tasks/task_e_6841f78631ec8327890a63617b39f99e