### PR TITLE
Add consistent hash ring for Dynamo service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,7 @@ node_modules/
 !.yarn/versions
 client/dist/
 client/.yarn/*
+
+# .NET build folders
+Src/*/obj/
+Src/*/bin/

--- a/Src/Nemcache.DynamoService/Grains/IPartitionGrain.cs
+++ b/Src/Nemcache.DynamoService/Grains/IPartitionGrain.cs
@@ -1,0 +1,13 @@
+using System.Threading.Tasks;
+using Orleans;
+
+namespace Nemcache.DynamoService.Grains
+{
+    public interface IPartitionGrain : IGrainWithStringKey
+    {
+        Task PutAsync(string key, byte[] value);
+        Task PutReplicaAsync(string key, byte[] value);
+        Task<byte[]?> GetAsync(string key);
+        Task<byte[]?> GetReplicaAsync(string key);
+    }
+}

--- a/Src/Nemcache.DynamoService/Grains/PartitionGrain.cs
+++ b/Src/Nemcache.DynamoService/Grains/PartitionGrain.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Nemcache.DynamoService.Routing;
+using Nemcache.Storage;
+using Orleans;
+
+namespace Nemcache.DynamoService.Grains
+{
+    public class PartitionGrain : Grain, IPartitionGrain
+    {
+        private readonly IMemCache _cache;
+        private readonly RingProvider _ring;
+        private const int ReplicaCount = 3;
+
+        public PartitionGrain(IMemCache cache, RingProvider ring)
+        {
+            _cache = cache;
+            _ring = ring;
+        }
+
+        public async Task PutAsync(string key, byte[] value)
+        {
+            _cache.Store(key, 0, value, DateTime.MaxValue);
+
+            var replicas = _ring.GetReplicas(key).Skip(1);
+            foreach (var replicaKey in replicas)
+            {
+                var replica = GrainFactory.GetGrain<IPartitionGrain>(replicaKey);
+                await replica.PutReplicaAsync(key, value);
+            }
+        }
+
+        public Task PutReplicaAsync(string key, byte[] value)
+        {
+            _cache.Store(key, 0, value, DateTime.MaxValue);
+            return Task.CompletedTask;
+        }
+
+        public async Task<byte[]?> GetAsync(string key)
+        {
+            var entry = _cache.Get(key);
+            if (entry.Data != null)
+            {
+                return entry.Data;
+            }
+
+            var replicas = _ring.GetReplicas(key).Skip(1);
+            foreach (var replicaKey in replicas)
+            {
+                var replica = GrainFactory.GetGrain<IPartitionGrain>(replicaKey);
+                var value = await replica.GetReplicaAsync(key);
+                if (value != null)
+                {
+                    return value;
+                }
+            }
+
+            return null;
+        }
+
+        public Task<byte[]?> GetReplicaAsync(string key)
+        {
+            var entry = _cache.Get(key);
+            return Task.FromResult<byte[]?>(entry.Data);
+        }
+    }
+}

--- a/Src/Nemcache.DynamoService/Nemcache.DynamoService.csproj
+++ b/Src/Nemcache.DynamoService/Nemcache.DynamoService.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Orleans.Server" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Nemcache.Storage\Nemcache.Storage.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Src/Nemcache.DynamoService/Program.cs
+++ b/Src/Nemcache.DynamoService/Program.cs
@@ -1,0 +1,37 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.Hosting;
+using Nemcache.Storage;
+using Nemcache.Storage.IO;
+using Nemcache.Storage.Persistence;
+using Nemcache.DynamoService.Grains;
+using Nemcache.DynamoService.Routing;
+
+var host = Host.CreateDefaultBuilder(args)
+    .UseOrleans(siloBuilder =>
+    {
+        siloBuilder.UseLocalhostClustering();
+    })
+    .ConfigureServices(services =>
+    {
+        services.AddSingleton<IMemCache>(sp =>
+            new MemCache(1024UL * 1024 * 1024, System.Reactive.Concurrency.Scheduler.Default));
+        services.AddSingleton(new RingProvider(partitionCount: 32, replicaCount: 3));
+        services.AddSingleton<IFileSystem, FileSystemWrapper>();
+        services.AddSingleton(sp => new StreamArchiver(
+            sp.GetRequiredService<IFileSystem>(),
+            "dynamo.log",
+            (MemCache)sp.GetRequiredService<IMemCache>(),
+            10_000));
+        services.AddSingleton<ICachePersistence>(sp =>
+        {
+            var cache = (MemCache)sp.GetRequiredService<IMemCache>();
+            var fs = sp.GetRequiredService<IFileSystem>();
+            var restorer = new CacheRestorer(cache, fs, "dynamo.log");
+            return new StreamPersistence(sp.GetRequiredService<StreamArchiver>(), restorer);
+        });
+    })
+    .Build();
+
+host.Services.GetRequiredService<ICachePersistence>().Restore();
+host.Run();

--- a/Src/Nemcache.DynamoService/Routing/ConsistentHashRing.cs
+++ b/Src/Nemcache.DynamoService/Routing/ConsistentHashRing.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Nemcache.DynamoService.Routing
+{
+    /// <summary>
+    /// Simple consistent hash ring for mapping keys to nodes.
+    /// </summary>
+    public class ConsistentHashRing
+    {
+        private readonly SortedDictionary<uint, string> _ring = new();
+        private readonly int _virtualNodes;
+
+        public ConsistentHashRing(IEnumerable<string> nodes, int virtualNodes = 100)
+        {
+            _virtualNodes = virtualNodes;
+            foreach (var n in nodes)
+            {
+                AddNode(n);
+            }
+        }
+
+        private static uint Hash(string key)
+        {
+            using var md5 = MD5.Create();
+            var bytes = md5.ComputeHash(Encoding.UTF8.GetBytes(key));
+            return BitConverter.ToUInt32(bytes, 0);
+        }
+
+        public void AddNode(string node)
+        {
+            for (int i = 0; i < _virtualNodes; i++)
+            {
+                _ring[Hash($"{node}-{i}")] = node;
+            }
+        }
+
+        public void RemoveNode(string node)
+        {
+            for (int i = 0; i < _virtualNodes; i++)
+            {
+                _ring.Remove(Hash($"{node}-{i}"));
+            }
+        }
+
+        public string GetNode(string key)
+        {
+            if (_ring.Count == 0)
+            {
+                throw new InvalidOperationException("Hash ring is empty");
+            }
+
+            uint hash = Hash(key);
+            foreach (var kv in _ring)
+            {
+                if (kv.Key >= hash)
+                    return kv.Value;
+            }
+            return _ring[_ring.First().Key];
+        }
+
+        public IEnumerable<string> GetNodes(string key, int count)
+        {
+            if (_ring.Count == 0) throw new InvalidOperationException("Hash ring is empty");
+            var keys = _ring.Keys.ToList();
+            uint hash = Hash(key);
+            int index = keys.BinarySearch(hash);
+            if (index < 0) index = ~index;
+            for (int i = 0; i < count; i++)
+            {
+                if (index >= keys.Count) index = 0;
+                yield return _ring[keys[index]];
+                index++;
+            }
+        }
+    }
+}

--- a/Src/Nemcache.DynamoService/Routing/RingProvider.cs
+++ b/Src/Nemcache.DynamoService/Routing/RingProvider.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Nemcache.DynamoService.Routing
+{
+    /// <summary>
+    /// Provides partition selection using a consistent hash ring.
+    /// </summary>
+    public class RingProvider
+    {
+        private readonly ConsistentHashRing _ring;
+        private readonly int _replicaCount;
+
+        public RingProvider(int partitionCount, int replicaCount)
+        {
+            _replicaCount = replicaCount;
+            var nodes = Enumerable.Range(0, partitionCount)
+                .Select(i => $"partition-{i}");
+            _ring = new ConsistentHashRing(nodes);
+        }
+
+        public IEnumerable<string> GetReplicas(string key)
+        {
+            return _ring.GetNodes(key, _replicaCount);
+        }
+    }
+}

--- a/Src/Nemcache.sln
+++ b/Src/Nemcache.sln
@@ -13,6 +13,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{2E97F31A
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nemcache.Storage", "Nemcache.Storage\Nemcache.Storage.csproj", "{A12B36A5-82C7-444A-B90A-0E22F0B77064}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nemcache.DynamoService", "Nemcache.DynamoService\Nemcache.DynamoService.csproj", "{24E39828-1085-4DC2-90B3-600C57A0CB62}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -39,6 +41,10 @@ Global
 		{A12B36A5-82C7-444A-B90A-0E22F0B77064}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A12B36A5-82C7-444A-B90A-0E22F0B77064}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A12B36A5-82C7-444A-B90A-0E22F0B77064}.Release|Any CPU.Build.0 = Release|Any CPU
+		{24E39828-1085-4DC2-90B3-600C57A0CB62}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{24E39828-1085-4DC2-90B3-600C57A0CB62}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{24E39828-1085-4DC2-90B3-600C57A0CB62}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{24E39828-1085-4DC2-90B3-600C57A0CB62}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/docs/dynamo-service.md
+++ b/docs/dynamo-service.md
@@ -1,0 +1,16 @@
+# Dynamo-like Service
+
+`Nemcache.DynamoService` is an Orleans-based host that stores partition data using the existing persistent `MemCache` implementation.
+
+The project demonstrates how Nemcache can integrate with Orleans to build a Dynamo-inspired architecture. Each partition is represented by a grain and writes are persisted using the Nemcache storage engine.
+
+Grains replicate each write to two additional replicas to mimic Dynamo's N-way replication.
+
+Keys are routed to partitions using a simple consistent hashing ring so that data remains evenly distributed if the number of partitions changes.
+
+Run the service with:
+
+```bash
+cd Src
+dotnet run --project Nemcache.DynamoService
+```


### PR DESCRIPTION
## Summary
- implement a simple consistent hash ring and `RingProvider`
- integrate `RingProvider` in `PartitionGrain` for replica selection
- register the ring in the Dynamo service host
- document consistent hashing in Dynamo service docs

## Testing
- `dotnet build Src/Nemcache.DynamoService/Nemcache.DynamoService.csproj -warnaserror`
- `dotnet test Src/Nemcache.sln` *(fails: ObjectDisposedException during test run)*

------
https://chatgpt.com/codex/tasks/task_e_68475c329ab483279d1f0bf3ad932ab8