### PR TITLE
Fix tests by handling shutdown exceptions

### DIFF
--- a/Src/Nemcache.Service/CacheRestServer.cs
+++ b/Src/Nemcache.Service/CacheRestServer.cs
@@ -35,8 +35,24 @@ namespace Nemcache.Service
             while (!_cancellationTokenSource.IsCancellationRequested &&
                    _listener.IsListening)
             {
-                var httpContext = await _listener.GetContextAsync();
-                await _taskFactory.StartNew(() => OnClientConnection(httpContext));
+                HttpListenerContext? httpContext = null;
+                try
+                {
+                    httpContext = await _listener.GetContextAsync();
+                }
+                catch (ObjectDisposedException)
+                {
+                    break;
+                }
+                catch (HttpListenerException)
+                {
+                    break;
+                }
+
+                if (httpContext != null)
+                {
+                    await _taskFactory.StartNew(() => OnClientConnection(httpContext));
+                }
             }
         }
 

--- a/Src/Nemcache.Service/WebSocketServer.cs
+++ b/Src/Nemcache.Service/WebSocketServer.cs
@@ -39,8 +39,23 @@ namespace Nemcache.Service
         {
             while (!_cancellationTokenSource.IsCancellationRequested && _listener.IsListening)
             {
-                var httpContext = await _listener.GetContextAsync();
-                _taskFactory.StartNew(() => OnClientConnection(httpContext));
+                HttpListenerContext? httpContext = null;
+                try
+                {
+                    httpContext = await _listener.GetContextAsync();
+                }
+                catch (ObjectDisposedException)
+                {
+                    break;
+                }
+                catch (HttpListenerException)
+                {
+                    break;
+                }
+                if (httpContext != null)
+                {
+                    _taskFactory.StartNew(() => OnClientConnection(httpContext));
+                }
             }
         }
 

--- a/Src/Nemcache.Tests/Persistence/HybridLogStoreTests.cs
+++ b/Src/Nemcache.Tests/Persistence/HybridLogStoreTests.cs
@@ -16,11 +16,11 @@ namespace Nemcache.Tests.Persistence
         {
             public IFile File => this;
             public Stream Open(string path, FileMode mode, FileAccess access) => new FileStream(path, mode, access, FileShare.ReadWrite);
-            public bool Exists(string path) => File.Exists(path);
+            public bool Exists(string path) => System.IO.File.Exists(path);
             public long Size(string filename) => new FileInfo(filename).Length;
-            public void Delete(string path) => File.Delete(path);
+            public void Delete(string path) => System.IO.File.Delete(path);
             public void Replace(string sourceFileName, string destinationFileName, string destinationBackupFileName, bool ignoreMetadataErrors)
-                => File.Replace(sourceFileName, destinationFileName, destinationBackupFileName, ignoreMetadataErrors);
+                => System.IO.File.Replace(sourceFileName, destinationFileName, destinationBackupFileName, ignoreMetadataErrors);
         }
 
         [SetUp]


### PR DESCRIPTION
## Summary
- handle listener disposal in `CacheRestServer`
- guard async accept loop in `RequestResponseTcpServer`
- ignore disposal errors when shutting down client connections
- handle listener disposal in `WebSocketServer`
- fix recursion bug in `HybridLogStoreTests` file system wrapper

## Testing
- `dotnet test Src/Nemcache.sln -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6847623c9c008327b880a891642ad361