### PR TITLE
Introduce partition cache factory

### DIFF
--- a/Src/Nemcache.DynamoService/Grains/PartitionGrain.cs
+++ b/Src/Nemcache.DynamoService/Grains/PartitionGrain.cs
@@ -2,26 +2,52 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Nemcache.DynamoService.Routing;
+using Nemcache.DynamoService.Services;
 using Nemcache.Storage;
+using Nemcache.Storage.IO;
+using Nemcache.Storage.Persistence;
 using Orleans;
 
 namespace Nemcache.DynamoService.Grains
 {
     public class PartitionGrain : Grain, IPartitionGrain
     {
-        private readonly IMemCache _cache;
+        private IMemCache? _cache;
         private readonly RingProvider _ring;
+        private readonly IMemCacheFactory _cacheFactory;
+        private readonly IFileSystem _fileSystem;
+        private ICachePersistence? _persistence;
         private const int ReplicaCount = 3;
 
-        public PartitionGrain(IMemCache cache, RingProvider ring)
+        public PartitionGrain(IMemCacheFactory cacheFactory, RingProvider ring, IFileSystem fileSystem)
         {
-            _cache = cache;
+            _cacheFactory = cacheFactory;
             _ring = ring;
+            _fileSystem = fileSystem;
+        }
+
+        public override Task OnActivateAsync()
+        {
+            _cache = _cacheFactory.Create();
+            var logPath = $"{this.GetPrimaryKeyString()}.log";
+            var archiver = new StreamArchiver(_fileSystem, logPath, (MemCache)_cache, 10_000);
+            var restorer = new CacheRestorer(_cache, _fileSystem, logPath);
+            _persistence = new StreamPersistence(archiver, restorer);
+            _cache.Notifications.Subscribe(_persistence);
+            _persistence.Restore();
+            return base.OnActivateAsync();
+        }
+
+        public override Task OnDeactivateAsync()
+        {
+            _persistence?.Dispose();
+            _cache?.Dispose();
+            return base.OnDeactivateAsync();
         }
 
         public async Task PutAsync(string key, byte[] value)
         {
-            _cache.Store(key, 0, value, DateTime.MaxValue);
+            _cache!.Store(key, 0, value, DateTime.MaxValue);
 
             var replicas = _ring.GetReplicas(key).Skip(1);
             foreach (var replicaKey in replicas)
@@ -33,13 +59,13 @@ namespace Nemcache.DynamoService.Grains
 
         public Task PutReplicaAsync(string key, byte[] value)
         {
-            _cache.Store(key, 0, value, DateTime.MaxValue);
+            _cache!.Store(key, 0, value, DateTime.MaxValue);
             return Task.CompletedTask;
         }
 
         public async Task<byte[]?> GetAsync(string key)
         {
-            var entry = _cache.Get(key);
+            var entry = _cache!.Get(key);
             if (entry.Data != null)
             {
                 return entry.Data;
@@ -61,7 +87,7 @@ namespace Nemcache.DynamoService.Grains
 
         public Task<byte[]?> GetReplicaAsync(string key)
         {
-            var entry = _cache.Get(key);
+            var entry = _cache!.Get(key);
             return Task.FromResult<byte[]?>(entry.Data);
         }
     }

--- a/Src/Nemcache.DynamoService/Services/IMemCacheFactory.cs
+++ b/Src/Nemcache.DynamoService/Services/IMemCacheFactory.cs
@@ -1,0 +1,9 @@
+using Nemcache.Storage;
+
+namespace Nemcache.DynamoService.Services
+{
+    public interface IMemCacheFactory
+    {
+        IMemCache Create();
+    }
+}

--- a/Src/Nemcache.DynamoService/Services/MemCacheFactory.cs
+++ b/Src/Nemcache.DynamoService/Services/MemCacheFactory.cs
@@ -1,0 +1,22 @@
+using System.Reactive.Concurrency;
+using Nemcache.Storage;
+
+namespace Nemcache.DynamoService.Services
+{
+    public class MemCacheFactory : IMemCacheFactory
+    {
+        private readonly ulong _capacity;
+        private readonly IScheduler _scheduler;
+
+        public MemCacheFactory(ulong capacity, IScheduler scheduler)
+        {
+            _capacity = capacity;
+            _scheduler = scheduler;
+        }
+
+        public IMemCache Create()
+        {
+            return new MemCache(_capacity, _scheduler);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a simple `IMemCacheFactory` service to create caches
- register the factory in DynamoService and remove global cache persistence
- update `PartitionGrain` so each grain creates and persists its own cache

## Testing
- `dotnet test Src/Nemcache.Tests/Nemcache.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_684766d62a688327bfc9716ab34974af