### PR TITLE
Implement read repair in PartitionGrain

### DIFF
--- a/Src/Nemcache.DynamoService/Grains/PartitionGrain.cs
+++ b/Src/Nemcache.DynamoService/Grains/PartitionGrain.cs
@@ -45,13 +45,24 @@ namespace Nemcache.DynamoService.Grains
                 return entry.Data;
             }
 
-            var replicas = _ring.GetReplicas(key).Skip(1);
-            foreach (var replicaKey in replicas)
+            var replicaKeys = _ring.GetReplicas(key).ToArray();
+            // Skip the local partition when querying replicas
+            foreach (var replicaKey in replicaKeys.Where(k => k != this.GetPrimaryKeyString()))
             {
                 var replica = GrainFactory.GetGrain<IPartitionGrain>(replicaKey);
                 var value = await replica.GetReplicaAsync(key);
                 if (value != null)
                 {
+                    // Store locally for read-repair
+                    _cache.Store(key, 0, value, DateTime.MaxValue);
+
+                    // Forward to the remaining replicas for full repair
+                    foreach (var forwardKey in replicaKeys.Where(k => k != replicaKey && k != this.GetPrimaryKeyString()))
+                    {
+                        var forwardReplica = GrainFactory.GetGrain<IPartitionGrain>(forwardKey);
+                        await forwardReplica.PutReplicaAsync(key, value);
+                    }
+
                     return value;
                 }
             }


### PR DESCRIPTION
## Summary
- repair inconsistent replicas on read
- store the value locally after reading from a replica and forward it to the remaining replicas

## Testing
- `dotnet test Src/Nemcache.Tests/Nemcache.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_684766d882508327a5c24a3b9b30e875