### PR TITLE
Add configurable replica count

### DIFF
--- a/Src/Nemcache.DynamoService/Grains/PartitionGrain.cs
+++ b/Src/Nemcache.DynamoService/Grains/PartitionGrain.cs
@@ -11,7 +11,6 @@ namespace Nemcache.DynamoService.Grains
     {
         private readonly IMemCache _cache;
         private readonly RingProvider _ring;
-        private const int ReplicaCount = 3;
 
         public PartitionGrain(IMemCache cache, RingProvider ring)
         {

--- a/Src/Nemcache.DynamoService/Routing/RingProviderOptions.cs
+++ b/Src/Nemcache.DynamoService/Routing/RingProviderOptions.cs
@@ -1,0 +1,11 @@
+namespace Nemcache.DynamoService.Routing
+{
+    /// <summary>
+    /// Options controlling the behaviour of <see cref="RingProvider"/>.
+    /// </summary>
+    public class RingProviderOptions
+    {
+        public int PartitionCount { get; set; }
+        public int ReplicaCount { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- drop unused `ReplicaCount` constant from `PartitionGrain`
- create `RingProviderOptions` for DI configuration
- register `RingProvider` via options in Dynamo service

## Testing
- `dotnet test Src/Nemcache.Tests/Nemcache.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_684766dab25c8327898fe9436321be31