### PR TITLE
Add DynamoService tests

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -19,4 +19,6 @@ jobs:
     - name: Build
       run: dotnet build Src/Nemcache.Service/Nemcache.Service.csproj --no-restore --configuration Release
     - name: Test
-      run: dotnet test Src/Nemcache.Tests/Nemcache.Tests.csproj --no-build --configuration Release
+      run: |
+        dotnet test Src/Nemcache.Tests/Nemcache.Tests.csproj --no-build --configuration Release
+        dotnet test Src/Nemcache.DynamoService.Tests/Nemcache.DynamoService.Tests.csproj --no-build --configuration Release

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -20,5 +20,5 @@ jobs:
       run: dotnet build Src/Nemcache.Service/Nemcache.Service.csproj --no-restore --configuration Release
     - name: Test
       run: |
-        dotnet test Src/Nemcache.Tests/Nemcache.Tests.csproj --no-build --configuration Release
-        dotnet test Src/Nemcache.DynamoService.Tests/Nemcache.DynamoService.Tests.csproj --no-build --configuration Release
+        dotnet test Src/Nemcache.Tests/Nemcache.Tests.csproj --configuration Release
+        dotnet test Src/Nemcache.DynamoService.Tests/Nemcache.DynamoService.Tests.csproj --configuration Release

--- a/README.md
+++ b/README.md
@@ -89,3 +89,12 @@ strategy has strengths:
 * **Complexity** – The stream approach is simple to implement. Bitcask adds file
   management and indexing logic in exchange for improved performance on large
   data sets.
+
+## Running Tests
+
+Run all unit tests with:
+
+```bash
+dotnet test Src/Nemcache.Tests/Nemcache.Tests.csproj
+dotnet test Src/Nemcache.DynamoService.Tests/Nemcache.DynamoService.Tests.csproj
+```

--- a/Src/Nemcache.DynamoService.Tests/ConsistentHashRingTests.cs
+++ b/Src/Nemcache.DynamoService.Tests/ConsistentHashRingTests.cs
@@ -1,0 +1,29 @@
+using NUnit.Framework;
+using Nemcache.DynamoService.Routing;
+using System.Linq;
+
+namespace Nemcache.DynamoService.Tests;
+
+[TestFixture]
+public class ConsistentHashRingTests
+{
+    [Test]
+    public void Distribution_is_fair_across_nodes()
+    {
+        var nodes = Enumerable.Range(0, 4).Select(i => $"n{i}").ToArray();
+        var ring = new ConsistentHashRing(nodes);
+        var counts = nodes.ToDictionary(n => n, _ => 0);
+
+        for (int i = 0; i < 1000; i++)
+        {
+            var node = ring.GetNode($"key-{i}");
+            counts[node]++;
+        }
+
+        var avg = counts.Values.Average();
+        foreach (var c in counts.Values)
+        {
+            Assert.That(c, Is.InRange(avg * 0.5, avg * 1.5));
+        }
+    }
+}

--- a/Src/Nemcache.DynamoService.Tests/Nemcache.DynamoService.Tests.csproj
+++ b/Src/Nemcache.DynamoService.Tests/Nemcache.DynamoService.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.9.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="Microsoft.Orleans.TestingHost" Version="8.0.0" />
+    <PackageReference Include="Moq" Version="4.18.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="NUnit.Framework" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Nemcache.DynamoService\Nemcache.DynamoService.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Src/Nemcache.DynamoService.Tests/PartitionGrainTests.cs
+++ b/Src/Nemcache.DynamoService.Tests/PartitionGrainTests.cs
@@ -1,0 +1,85 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using Orleans.Hosting;
+using Orleans.TestingHost;
+using Nemcache.DynamoService.Grains;
+using Nemcache.DynamoService.Routing;
+using Nemcache.Storage;
+using System.Reactive.Concurrency;
+
+namespace Nemcache.DynamoService.Tests;
+
+[TestFixture]
+public class PartitionGrainTests
+{
+    private TestCluster? _cluster;
+    private RingProvider? _provider;
+
+    [OneTimeSetUp]
+    public void SetUp()
+    {
+        var builder = new TestClusterBuilder(1);
+        builder.AddSiloBuilderConfigurator<SiloConfigurator>();
+        _cluster = builder.Build();
+        _cluster.Deploy();
+        _provider = new RingProvider(partitionCount: 4, replicaCount: 3);
+    }
+
+    [OneTimeTearDown]
+    public void TearDown()
+    {
+        _cluster?.StopAllSilos();
+        _cluster?.Dispose();
+    }
+
+    private class SiloConfigurator : ISiloConfigurator
+    {
+        public void Configure(ISiloBuilder siloBuilder)
+        {
+            siloBuilder.ConfigureServices(services =>
+            {
+                services.AddSingleton<IMemCache>(sp => new MemCache(1024 * 1024, Scheduler.Default));
+                services.AddSingleton(new RingProvider(partitionCount: 4, replicaCount: 3));
+            });
+        }
+    }
+
+    [Test]
+    public async Task PutAsync_replicates_to_all_nodes()
+    {
+        var key = "key0";
+        var data = new byte[] {1,2,3};
+        var replicas = _provider!.GetReplicas(key).ToArray();
+        var primary = replicas.First();
+
+        var grain = _cluster!.GrainFactory.GetGrain<IPartitionGrain>(primary);
+        await grain.PutAsync(key, data);
+
+        foreach (var replica in replicas)
+        {
+            var repGrain = _cluster.GrainFactory.GetGrain<IPartitionGrain>(replica);
+            var stored = await repGrain.GetReplicaAsync(key);
+            Assert.That(stored, Is.EqualTo(data));
+        }
+    }
+
+    [Test]
+    public async Task GetAsync_fetches_from_replicas()
+    {
+        var key = "key0";
+        var data = new byte[] {5,4,3};
+        var replicas = _provider!.GetReplicas(key).ToArray();
+        var primary = replicas.First();
+
+        var grain = _cluster!.GrainFactory.GetGrain<IPartitionGrain>(primary);
+        await grain.PutAsync(key, data);
+
+        // call from a node not containing a replica
+        var other = Enumerable.Range(0,4).Select(i => $"partition-{i}").Except(replicas).First();
+        var otherGrain = _cluster.GrainFactory.GetGrain<IPartitionGrain>(other);
+        var value = await otherGrain.GetAsync(key);
+        Assert.That(value, Is.EqualTo(data));
+    }
+}

--- a/Src/Nemcache.DynamoService.Tests/RingProviderTests.cs
+++ b/Src/Nemcache.DynamoService.Tests/RingProviderTests.cs
@@ -1,0 +1,28 @@
+using NUnit.Framework;
+using Nemcache.DynamoService.Routing;
+using System.Linq;
+
+namespace Nemcache.DynamoService.Tests;
+
+[TestFixture]
+public class RingProviderTests
+{
+    [Test]
+    public void GetReplicas_returns_even_distribution()
+    {
+        var provider = new RingProvider(partitionCount: 8, replicaCount: 3);
+        var counts = Enumerable.Range(0, 8).Select(i => $"partition-{i}").ToDictionary(n => n, _ => 0);
+
+        for (int i = 0; i < 1000; i++)
+        {
+            var partition = provider.GetReplicas($"key-{i}").First();
+            counts[partition]++;
+        }
+
+        var avg = counts.Values.Average();
+        foreach (var c in counts.Values)
+        {
+            Assert.That(c, Is.InRange(avg * 0.5, avg * 1.5));
+        }
+    }
+}

--- a/Src/Nemcache.sln
+++ b/Src/Nemcache.sln
@@ -15,6 +15,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nemcache.Storage", "Nemcach
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nemcache.DynamoService", "Nemcache.DynamoService\Nemcache.DynamoService.csproj", "{24E39828-1085-4DC2-90B3-600C57A0CB62}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nemcache.DynamoService.Tests", "Nemcache.DynamoService.Tests\Nemcache.DynamoService.Tests.csproj", "{52733778-4C21-4F28-A215-9EC7DC8A3488}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -45,6 +47,10 @@ Global
 		{24E39828-1085-4DC2-90B3-600C57A0CB62}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{24E39828-1085-4DC2-90B3-600C57A0CB62}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{24E39828-1085-4DC2-90B3-600C57A0CB62}.Release|Any CPU.Build.0 = Release|Any CPU
+		{52733778-4C21-4F28-A215-9EC7DC8A3488}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{52733778-4C21-4F28-A215-9EC7DC8A3488}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{52733778-4C21-4F28-A215-9EC7DC8A3488}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{52733778-4C21-4F28-A215-9EC7DC8A3488}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
- add `Nemcache.DynamoService.Tests` project for the Dynamo service
- write tests for `ConsistentHashRing`, `RingProvider`, and `PartitionGrain`
- update solution and CI workflow to run the new tests
- document how to run all tests

## Testing
- `dotnet test Src/Nemcache.Tests/Nemcache.Tests.csproj`
- `dotnet test Src/Nemcache.DynamoService.Tests/Nemcache.DynamoService.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_684766df160c8327bee463cffe78bee4