### PR TITLE
Fix DynamoService startup

### DIFF
--- a/Src/Nemcache.DynamoService/Grains/PartitionGrain.cs
+++ b/Src/Nemcache.DynamoService/Grains/PartitionGrain.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Threading;
 using Nemcache.DynamoService.Routing;
 using Nemcache.DynamoService.Services;
 using Nemcache.Storage;
@@ -25,7 +26,7 @@ namespace Nemcache.DynamoService.Grains
             _fileSystem = fileSystem;
         }
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             _cache = _cacheFactory.Create();
             var logPath = $"{this.GetPrimaryKeyString()}.log";
@@ -34,14 +35,14 @@ namespace Nemcache.DynamoService.Grains
             _persistence = new StreamPersistence(archiver, restorer);
             _cache.Notifications.Subscribe(_persistence);
             _persistence.Restore();
-            return base.OnActivateAsync();
+            return base.OnActivateAsync(cancellationToken);
         }
 
-        public override Task OnDeactivateAsync()
+        public override Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
         {
             _persistence?.Dispose();
             _cache?.Dispose();
-            return base.OnDeactivateAsync();
+            return base.OnDeactivateAsync(reason, cancellationToken);
         }
 
         public async Task PutAsync(string key, byte[] value)

--- a/Src/Nemcache.DynamoService/Program.cs
+++ b/Src/Nemcache.DynamoService/Program.cs
@@ -32,10 +32,6 @@ var host = Host.CreateDefaultBuilder(args)
             return new RingProvider(opts.PartitionCount, opts.ReplicaCount);
         });
 
-        services.AddSingleton<IMemCacheFactory>(sp =>
-            new MemCacheFactory(1024UL * 1024 * 1024,
-                System.Reactive.Concurrency.Scheduler.Default));
-        services.AddSingleton(new RingProvider(partitionCount: 32, replicaCount: 3));
         services.AddSingleton<IFileSystem, FileSystemWrapper>();
         // Persistence is handled per partition grain
     })


### PR DESCRIPTION
## Summary
- clean up duplicate service registrations in `Program` for DynamoService
- update `PartitionGrain` lifecycle overrides for Orleans 8

## Testing
- `dotnet test Src/Nemcache.Tests/Nemcache.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_6847dc1c1f488327af45395a9e53cfd7