### PR TITLE
Add stats command and unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ sc start Nemcache
 
 ## Status
 
-The following commands from the [Memcached specification](https://raw.github.com/memcached/memcached/master/doc/protocol.txt) 
-are implemented: get (and gets), set, add, replace, delete, append, prepend, incr, decr, touch, flush_all, cas, quit and version.
+The following commands from the [Memcached specification](https://raw.github.com/memcached/memcached/master/doc/protocol.txt)
+are implemented: get (and gets), set, add, replace, delete, append, prepend, incr, decr, touch, flush_all, cas, quit, stats (including `stats settings`) and version.
  
 Currently only TCP is supported including the noreply mode. 
 

--- a/Src/Nemcache.Service/MemcacheRequestHandlers/StatsHandler.cs
+++ b/Src/Nemcache.Service/MemcacheRequestHandlers/StatsHandler.cs
@@ -1,13 +1,51 @@
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
 using Nemcache.Storage;
-﻿using System;
 
 namespace Nemcache.Service.RequestHandlers
 {
     internal class StatsHandler : IRequestHandler
     {
+        private readonly IMemCache _cache;
+        private readonly DateTime _startTime;
+
+        public StatsHandler(IMemCache cache)
+        {
+            _cache = cache;
+            _startTime = DateTime.UtcNow;
+        }
+
         public void HandleRequest(IRequestContext context)
         {
-            throw new NotImplementedException();
+            var args = context.Parameters.ToArray();
+            string response;
+
+            if (args.Length > 0 && args[0].Equals("settings", StringComparison.OrdinalIgnoreCase))
+            {
+                response = $"STAT maxbytes {_cache.Capacity}\r\nEND\r\n";
+            }
+            else
+            {
+                var sb = new StringBuilder();
+                sb.AppendFormat("STAT pid {0}\r\n", Process.GetCurrentProcess().Id);
+                var uptime = (int)(DateTime.UtcNow - _startTime).TotalSeconds;
+                sb.AppendFormat("STAT uptime {0}\r\n", uptime);
+                sb.AppendFormat("STAT time {0}\r\n", DateTimeOffset.UtcNow.ToUnixTimeSeconds());
+                sb.AppendFormat("STAT version {0}\r\n", GetType().Assembly.GetName().Version);
+                sb.AppendFormat("STAT pointer_size {0}\r\n", IntPtr.Size * 8);
+                sb.AppendFormat("STAT curr_items {0}\r\n", _cache.Keys.Count());
+                sb.AppendFormat("STAT bytes {0}\r\n", _cache.Used);
+                sb.AppendFormat("STAT limit_maxbytes {0}\r\n", _cache.Capacity);
+                sb.AppendFormat("STAT threads {0}\r\n", 1);
+                sb.Append("END\r\n");
+                response = sb.ToString();
+            }
+
+            var bytes = Encoding.ASCII.GetBytes(response);
+            context.ResponseStream.WriteAsync(bytes, 0, bytes.Length);
         }
     }
 }
+

--- a/Src/Nemcache.Service/Service.cs
+++ b/Src/Nemcache.Service/Service.cs
@@ -45,7 +45,23 @@ namespace Nemcache.Service
             var mutateHandler = new MutateHandler(helpers, cache, scheduler);
             return new Dictionary<string, IRequestHandler>
                 {
-                    {"get", getHandler}, {"gets", getHandler}, {"set", new SetHandler(helpers, cache)}, {"append", new AppendHandler(helpers, cache)}, {"prepend", new PrependHandler(helpers, cache)}, {"add", new AddHandler(helpers, cache)}, {"replace", new ReplaceHandler(helpers, cache)}, {"cas", new CasHandler(helpers, cache)}, {"stats", new StatsHandler()}, {"delete", new DeleteHandler(helpers, cache)}, {"flush_all", new FlushHandler(cache, scheduler)}, {"quit", new QuitHandler()}, {"exception", new ExceptionHandler()}, {"version", new VersionHandler()}, {"touch", new TouchHandler(helpers, cache)}, {"incr", mutateHandler}, {"decr", mutateHandler},
+                    {"get", getHandler},
+                    {"gets", getHandler},
+                    {"set", new SetHandler(helpers, cache)},
+                    {"append", new AppendHandler(helpers, cache)},
+                    {"prepend", new PrependHandler(helpers, cache)},
+                    {"add", new AddHandler(helpers, cache)},
+                    {"replace", new ReplaceHandler(helpers, cache)},
+                    {"cas", new CasHandler(helpers, cache)},
+                    {"stats", new StatsHandler(cache)},
+                    {"delete", new DeleteHandler(helpers, cache)},
+                    {"flush_all", new FlushHandler(cache, scheduler)},
+                    {"quit", new QuitHandler()},
+                    {"exception", new ExceptionHandler()},
+                    {"version", new VersionHandler()},
+                    {"touch", new TouchHandler(helpers, cache)},
+                    {"incr", mutateHandler},
+                    {"decr", mutateHandler},
                 };
 
         }

--- a/Src/Nemcache.Tests/RequestHandlerTests/RequestHandlerTests.cs
+++ b/Src/Nemcache.Tests/RequestHandlerTests/RequestHandlerTests.cs
@@ -60,15 +60,20 @@ namespace Nemcache.Tests.RequestHandlerIntegrationTests
         [Test]
         public void Stats()
         {
-            // TODO: implement
             var result = Dispatch(Encoding.ASCII.GetBytes("stats\r\n"));
+            var text = result.ToAsciiString();
+            StringAssert.Contains("STAT version", text);
+            StringAssert.Contains("STAT uptime", text);
+            StringAssert.EndsWith("END\r\n", text);
         }
 
         [Test]
         public void StatsSettings()
         {
-            // TODO: implement
             var result = Dispatch(Encoding.ASCII.GetBytes("stats settings\r\n"));
+            var text = result.ToAsciiString();
+            StringAssert.Contains("STAT maxbytes", text);
+            StringAssert.EndsWith("END\r\n", text);
         }
     }
 }


### PR DESCRIPTION
## Summary
- implement stats handler with uptime, version and memory info
- wire stats handler into service request map
- test stats and stats settings
- document stats support in README

## Testing
- `dotnet test Src/Nemcache.Tests/Nemcache.Tests.csproj`
- `yarn install` *(fails: command not found)*
- `yarn build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684766775ea08327bc43daf52e9a02b1