### PR TITLE
Validate memcache key characters

### DIFF
--- a/Src/Nemcache.Service/RequestConverters.cs
+++ b/Src/Nemcache.Service/RequestConverters.cs
@@ -29,7 +29,11 @@ namespace Nemcache.Service
         {
             if (key.Length > 250)
                 throw new InvalidOperationException("Key too long");
-            // TODO: no control chars
+            foreach (var c in key)
+            {
+                if (c < 0x20 || c == 0x7F)
+                    throw new InvalidOperationException("Key contains control characters");
+            }
             return key;
         }
 

--- a/Src/Nemcache.Tests/RequestConvertersTests.cs
+++ b/Src/Nemcache.Tests/RequestConvertersTests.cs
@@ -1,0 +1,33 @@
+using System;
+using Microsoft.Reactive.Testing;
+using NUnit.Framework;
+using Nemcache.Service;
+
+namespace Nemcache.Tests
+{
+    [TestFixture]
+    public class RequestConvertersTests
+    {
+        private RequestConverters _converters;
+
+        [SetUp]
+        public void Setup()
+        {
+            _converters = new RequestConverters(new TestScheduler());
+        }
+
+        [Test]
+        public void ToKey_AllowsValidKey()
+        {
+            const string key = "valid-key";
+            Assert.AreEqual(key, _converters.ToKey(key));
+        }
+
+        [Test]
+        public void ToKey_RejectsControlCharacters()
+        {
+            Assert.Throws<InvalidOperationException>(() => _converters.ToKey("bad\nkey"));
+            Assert.Throws<InvalidOperationException>(() => _converters.ToKey("bad\u007Fkey"));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- enforce ASCII control character check in `RequestConverters.ToKey`
- add unit tests for valid and invalid keys

## Testing
- `dotnet test Src/Nemcache.Tests/Nemcache.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_6847f20192448327a0a46777bc69e030