### PR TITLE
Expand ConsistentHashRing test coverage

### DIFF
--- a/Src/Nemcache.DynamoService.Tests/ConsistentHashRingTests.cs
+++ b/Src/Nemcache.DynamoService.Tests/ConsistentHashRingTests.cs
@@ -1,5 +1,6 @@
 using NUnit.Framework;
 using Nemcache.DynamoService.Routing;
+using System;
 using System.Linq;
 
 namespace Nemcache.DynamoService.Tests;
@@ -25,5 +26,46 @@ public class ConsistentHashRingTests
         {
             Assert.That(c, Is.InRange(avg * 0.5, avg * 1.5));
         }
+    }
+
+    [Test]
+    public void Key_maps_consistently_through_add_and_remove()
+    {
+        var ring = new ConsistentHashRing(new[] { "a", "b" }, virtualNodes: 1);
+        const string key = "key0";
+
+        // Initial mapping
+        Assert.That(ring.GetNode(key), Is.EqualTo("b"));
+
+        // After adding a node
+        ring.AddNode("c");
+        Assert.That(ring.GetNode(key), Is.EqualTo("c"));
+        Assert.That(ring.GetNode(key), Is.EqualTo("c"));
+
+        // After removing the node
+        ring.RemoveNode("c");
+        Assert.That(ring.GetNode(key), Is.EqualTo("b"));
+    }
+
+    [Test]
+    public void GetNodes_returns_unique_nodes_and_wraps_when_exceeding_ring()
+    {
+        var ring = new ConsistentHashRing(new[] { "a", "b", "c" }, virtualNodes: 1);
+        const string key = "key0";
+
+        var firstThree = ring.GetNodes(key, 3).ToArray();
+        Assert.That(firstThree, Is.EqualTo(new[] { "c", "b", "a" }));
+        Assert.That(firstThree.Distinct().Count(), Is.EqualTo(3));
+
+        var fiveNodes = ring.GetNodes(key, 5).ToArray();
+        Assert.That(fiveNodes, Is.EqualTo(new[] { "c", "b", "a", "c", "b" }));
+    }
+
+    [Test]
+    public void GetNode_on_empty_ring_throws()
+    {
+        var ring = new ConsistentHashRing(Array.Empty<string>());
+        var ex = Assert.Throws<InvalidOperationException>(() => ring.GetNode("any"));
+        Assert.That(ex!.Message, Is.EqualTo("Hash ring is empty"));
     }
 }


### PR DESCRIPTION
## Summary
- Verify key mapping remains stable across node additions and removals
- Ensure `GetNodes` yields unique nodes and wraps around when count exceeds ring size
- Check `GetNode` throws on an empty ring

## Testing
- `dotnet test Src/Nemcache.DynamoService.Tests/Nemcache.DynamoService.Tests.csproj`
- `dotnet test Src/Nemcache.Tests/Nemcache.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a8e3a75b788327b11c4a56e8d7aecf