### PR TITLE
Add test to verify NullEvictionStrategy leaves cache unchanged

### DIFF
--- a/Src/Nemcache.Tests/Eviction/NullEvictionTests.cs
+++ b/Src/Nemcache.Tests/Eviction/NullEvictionTests.cs
@@ -1,4 +1,6 @@
-﻿using NUnit.Framework;
+using System;
+using NUnit.Framework;
+using Nemcache.Storage;
 using Nemcache.Storage.Eviction;
 
 namespace Nemcache.Tests.Eviction
@@ -9,8 +11,16 @@ namespace Nemcache.Tests.Eviction
         [Test]
         public void EvictDoesNothing()
         {
+            var cache = new MemCache(10);
+            cache.Store("key", 0, new byte[] {1}, DateTime.MaxValue);
+            var usedBefore = cache.Used;
+
             var strategy = new NullEvictionStrategy();
             strategy.EvictEntry();
+
+            CacheEntry entry;
+            Assert.IsTrue(cache.TryGet("key", out entry));
+            Assert.AreEqual(usedBefore, cache.Used);
         }
     }
 }


### PR DESCRIPTION
## Summary
- add unit test for NullEvictionStrategy to ensure eviction is a no-op

## Testing
- `dotnet test Src/Nemcache.Tests/Nemcache.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a8e3bafd2c8327b33ff5b561594062