### PR TITLE
test: make random eviction deterministic

### DIFF
--- a/Src/Nemcache.Tests/Eviction/RandomEvictionTests.cs
+++ b/Src/Nemcache.Tests/Eviction/RandomEvictionTests.cs
@@ -1,5 +1,7 @@
-﻿using System;
+using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Reactive.Concurrency;
 using NUnit.Framework;
 using Nemcache.Storage;
@@ -10,11 +12,20 @@ namespace Nemcache.Tests.Eviction
     [TestFixture]
     public class RandomEvictionTests
     {
+        private static RandomEvictionStrategy CreateStrategy(MemCache cache, int seed = 123)
+        {
+            var strategy = new RandomEvictionStrategy(cache);
+            typeof(RandomEvictionStrategy)
+                .GetField("_rng", BindingFlags.NonPublic | BindingFlags.Instance)
+                .SetValue(strategy, new Random(seed));
+            return strategy;
+        }
+
         [Test]
         public void EvictEmpty()
         {
-            var memCache = new MemCache(100, Scheduler.Default); //Consider using mock
-            var strategy = new RandomEvictionStrategy(memCache);
+            var memCache = new MemCache(100, Scheduler.Default);
+            var strategy = CreateStrategy(memCache);
             strategy.EvictEntry();
             Assert.IsFalse(memCache.Keys.Any());
         }
@@ -22,9 +33,9 @@ namespace Nemcache.Tests.Eviction
         [Test]
         public void EvictSingle()
         {
-            var memCache = new MemCache(100); //Consider using mock
-            memCache.Add("mykey", 0, DateTime.MaxValue, new byte[] {});
-            var strategy = new RandomEvictionStrategy(memCache);
+            var memCache = new MemCache(100);
+            memCache.Add("mykey", 0, DateTime.MaxValue, new byte[] { });
+            var strategy = CreateStrategy(memCache);
             strategy.EvictEntry();
             Assert.AreEqual(0, memCache.Keys.Count());
         }
@@ -32,12 +43,44 @@ namespace Nemcache.Tests.Eviction
         [Test]
         public void Evict2()
         {
-            var memCache = new MemCache(100); //Consider using mock
-            memCache.Add("mykey1", 0, DateTime.MaxValue, new byte[] {});
-            memCache.Add("mykey2", 0, DateTime.MaxValue, new byte[] {});
-            var strategy = new RandomEvictionStrategy(memCache);
+            var memCache = new MemCache(100);
+            memCache.Add("mykey1", 0, DateTime.MaxValue, new byte[] { });
+            memCache.Add("mykey2", 0, DateTime.MaxValue, new byte[] { });
+            var strategy = CreateStrategy(memCache);
             strategy.EvictEntry();
             Assert.AreEqual(1, memCache.Keys.Count());
+        }
+
+        [Test]
+        public void EvictRepeatedlyRemovesAllOriginalKeys()
+        {
+            var memCache = new MemCache(100);
+            var keys = new[] { "a", "b", "c", "d", "e" };
+            foreach (var key in keys)
+            {
+                memCache.Add(key, 0, DateTime.MaxValue, new byte[] { });
+            }
+
+            var strategy = CreateStrategy(memCache, seed: 42);
+            var remaining = new HashSet<string>(keys);
+            var removed = new HashSet<string>();
+
+            for (var i = 0; i < keys.Length; i++)
+            {
+                var before = memCache.Keys.ToList();
+                strategy.EvictEntry();
+                var after = memCache.Keys.ToList();
+
+                var removedKey = before.Except(after).Single();
+                Assert.IsTrue(remaining.Contains(removedKey));
+                remaining.Remove(removedKey);
+                removed.Add(removedKey);
+
+                CollectionAssert.AreEquivalent(remaining, after);
+            }
+
+            CollectionAssert.AreEquivalent(keys, removed);
+            Assert.IsFalse(memCache.Keys.Any());
         }
     }
 }


### PR DESCRIPTION
## Summary
- inject seeded Random into tests for repeatable random eviction
- add looped eviction test ensuring only original keys removed

## Testing
- `dotnet test Src/Nemcache.Tests/Nemcache.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a8e3bd9e548327aa32d2958dffcf89