### PR TITLE
Add error and disposal handling tests

### DIFF
--- a/Src/Nemcache.Storage/Reactive/CombineCurrentStateWithUpdatesExtension.cs
+++ b/Src/Nemcache.Storage/Reactive/CombineCurrentStateWithUpdatesExtension.cs
@@ -26,7 +26,8 @@ namespace Nemcache.Storage.Reactive
                     var disposable = new CompositeDisposable();
                     var notificationBuffer = new ConcurrentBag<ICacheNotification>();
 
-                    var liveSubscription = live.Subscribe(cacheNotification =>
+                    var liveSubscription = live.Subscribe(
+                        cacheNotification =>
                         {
                             if (notificationBuffer != null)
                             {
@@ -36,11 +37,13 @@ namespace Nemcache.Storage.Reactive
                             {
                                 obs.OnNext(cacheNotification);
                             }
-                        });
+                        },
+                        obs.OnError);
                     disposable.Add(liveSubscription);
 
                     var historicSubscription = historic.Subscribe(
                         n => { notificationBuffer.Add(n); },
+                        obs.OnError,
                         () =>
                             {
                                 var cacheNotifications = notificationBuffer.


### PR DESCRIPTION
## Summary
- cover error propagation from history and live streams in CombineCurrentStateWithUpdates
- verify mid-stream disposal releases subscriptions
- forward errors from history and live observables in Combine extension

## Testing
- `dotnet test Src/Nemcache.Tests/Nemcache.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a8e3b3003083279c0895b570ce6e69