### PR TITLE
Add persistence stress tests for compaction and crash recovery

### DIFF
--- a/Src/Nemcache.Tests/Persistence/HybridLogStoreTests.cs
+++ b/Src/Nemcache.Tests/Persistence/HybridLogStoreTests.cs
@@ -1,5 +1,7 @@
 using System;
 using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
 using NUnit.Framework;
 using Nemcache.Storage.IO;
 using Nemcache.Storage.Persistence;
@@ -81,6 +83,75 @@ namespace Nemcache.Tests.Persistence
                 store.Put("z", new byte[] {9});
                 store.Delete("z");
                 Assert.IsFalse(store.TryGet("z", out _));
+            }
+        }
+
+        [Test]
+        public void CompactionReducesLogFileSize()
+        {
+            var path = Path.Combine(_dir, "log.dat");
+            using (var store = new HybridLogStore(_fs, path, 20))
+            {
+                store.Put("a", new byte[] {1,2,3,4,5});
+                store.Put("a", new byte[] {6});
+                store.Put("b", new byte[] {7,8,9});
+                store.Delete("b");
+            }
+
+            var originalSize = new FileInfo(path).Length;
+            var compactPath = Path.Combine(_dir, "compact.dat");
+            using (var source = new HybridLogStore(_fs, path, 20))
+            using (var dest = new HybridLogStore(_fs, compactPath, 1024))
+            {
+                foreach (var entry in source.Entries())
+                    dest.Put(entry.Key, entry.Value);
+            }
+
+            var compactSize = new FileInfo(compactPath).Length;
+            Assert.Less(compactSize, originalSize);
+        }
+
+        [Test]
+        public void ParallelPutGetDeleteOperations()
+        {
+            var path = Path.Combine(_dir, "log.dat");
+            using (var store = new HybridLogStore(_fs, path, 100))
+            {
+                var gate = new object();
+                Parallel.For(0, 100, i =>
+                {
+                    var key = $"k{i}";
+                    lock (gate)
+                    {
+                        store.Put(key, new byte[] {1});
+                        Assert.IsTrue(store.TryGet(key, out _));
+                        store.Delete(key);
+                    }
+                });
+
+                Assert.IsEmpty(store.Keys);
+            }
+        }
+
+        [Test]
+        public void RecoversFromTruncatedLog()
+        {
+            var path = Path.Combine(_dir, "log.dat");
+            using (var store = new HybridLogStore(_fs, path, 100))
+            {
+                store.Put("good", new byte[] {1,2,3});
+                store.Put("bad", new byte[] {4,5,6});
+            }
+
+            using (var fs = new FileStream(path, FileMode.Open, FileAccess.Write))
+            {
+                fs.SetLength(fs.Length - 2);
+            }
+
+            using (var store = new HybridLogStore(_fs, path, 100))
+            {
+                Assert.IsTrue(store.TryGet("good", out var val));
+                CollectionAssert.AreEqual(new byte[] {1,2,3}, val);
             }
         }
     }


### PR DESCRIPTION
## Summary
- add bitcask store tests covering manual compaction, parallel operations, and truncated log recovery
- add hybrid log store tests for compaction, concurrent access, and crash recovery

## Testing
- `dotnet test Src/Nemcache.Tests/Nemcache.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68a8e3afc3388327b0b29e80a283e781