### PR TITLE
Add concurrency and expiry tests for MemCache

### DIFF
--- a/Src/Nemcache.Tests/MemcacheTest.cs
+++ b/Src/Nemcache.Tests/MemcacheTest.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Reactive.Testing;
 using NUnit.Framework;
 using Nemcache.Storage;
@@ -78,6 +80,53 @@ namespace Nemcache.Tests
             _testScheduler.AdvanceBy(TimeSpan.FromSeconds(11).Ticks);
 
             Assert.AreEqual(0UL, _cache.Used);
+        }
+
+        [Test]
+        public void UsedRemainsAccurateUnderConcurrentStoreAndRemove()
+        {
+            Parallel.For(0, 100, i =>
+            {
+                var key = "k" + i;
+                _cache.Store(key, 0, new byte[10], DateTime.MaxValue);
+                _cache.Remove(key);
+            });
+
+            Assert.AreEqual(0UL, _cache.Used);
+        }
+
+        [Test]
+        public void ImmediateExpiryExpiresItem()
+        {
+            _cache.Store("k", 0, new byte[10], DateTime.MinValue + TimeSpan.FromMilliseconds(1));
+            _testScheduler.AdvanceBy(TimeSpan.FromSeconds(1).Ticks);
+            CacheEntry entry;
+            var exists = _cache.TryGet("k", out entry);
+            Assert.IsFalse(exists);
+            Assert.AreEqual(0UL, _cache.Used);
+        }
+
+        [Test]
+        public void AddReplaceAtomicWhenConcurrent()
+        {
+            int addSuccess = 0;
+            Parallel.For(0, 10, i =>
+            {
+                if (_cache.Add("k", 0, DateTime.MaxValue, new byte[] { (byte)i }))
+                {
+                    Interlocked.Increment(ref addSuccess);
+                }
+            });
+            Assert.AreEqual(1, addSuccess);
+            Assert.AreEqual(1UL, _cache.Used);
+
+            Parallel.For(0, 10, i =>
+            {
+                _cache.Replace("k", 0, DateTime.MaxValue, new byte[] { (byte)i });
+            });
+            Assert.AreEqual(1UL, _cache.Used);
+            var value = _cache.Get("k").Data[0];
+            Assert.That(value, Is.InRange(0, 9));
         }
 
         [Test]


### PR DESCRIPTION
## Summary
- test Used accounting under concurrent store/remove operations
- ensure items with near-current TTL expire immediately
- verify Add/Replace operations remain atomic under concurrency

## Testing
- `dotnet test Src/Nemcache.Tests/Nemcache.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a8e3c0d0d88327a29d4e833e330a5f