### PR TITLE
Add resilience tests for partition grain replication

### DIFF
--- a/Src/Nemcache.DynamoService.Tests/PartitionGrainTests.cs
+++ b/Src/Nemcache.DynamoService.Tests/PartitionGrainTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
 using Orleans.Hosting;
 using Orleans.TestingHost;
+using Orleans.Runtime;
 using Nemcache.DynamoService.Grains;
 using Nemcache.DynamoService.Routing;
 using Nemcache.Storage;
@@ -11,6 +12,7 @@ using Nemcache.DynamoService.Services;
 using Nemcache.Storage.IO;
 using System.Reactive.Concurrency;
 using System.IO;
+using System;
 
 namespace Nemcache.DynamoService.Tests;
 
@@ -23,7 +25,7 @@ public class PartitionGrainTests
     [OneTimeSetUp]
     public void SetUp()
     {
-        var builder = new TestClusterBuilder(1);
+        var builder = new TestClusterBuilder(2);
         builder.AddSiloBuilderConfigurator<SiloConfigurator>();
         _cluster = builder.Build();
         _cluster.Deploy();
@@ -61,8 +63,28 @@ public class PartitionGrainTests
                 services.AddSingleton<IFileSystem, SharedFileSystem>();
                 services.AddSingleton(new RingProvider(partitionCount: 4, replicaCount: 3));
             });
+            siloBuilder.AddIncomingGrainCallFilter<FailingPutReplicaFilter>();
         }
     }
+
+    private class FailingPutReplicaFilter : IIncomingGrainCallFilter
+    {
+        public static string? OfflinePartition { get; set; }
+
+        public Task Invoke(IIncomingGrainCallContext context)
+        {
+            if (OfflinePartition != null &&
+                context.Grain is PartitionGrain pg &&
+                context.InterfaceMethod.Name == nameof(IPartitionGrain.PutReplicaAsync) &&
+                pg.GetPrimaryKeyString() == OfflinePartition)
+            {
+                throw new Exception("Replica offline");
+            }
+
+            return context.Invoke();
+        }
+    }
+
 
     [Test]
     public async Task PutAsync_replicates_to_all_nodes()
@@ -99,5 +121,87 @@ public class PartitionGrainTests
         var otherGrain = _cluster.GrainFactory.GetGrain<IPartitionGrain>(other);
         var value = await otherGrain.GetAsync(key);
         Assert.That(value, Is.EqualTo(data));
+    }
+
+    [Test]
+    public async Task PutAsync_recovers_when_replica_offline()
+    {
+        var key = "offline-key";
+        var data = new byte[] { 9 };
+        var replicas = _provider!.GetReplicas(key).ToArray();
+        var primary = replicas.First();
+        var offline = replicas.Skip(1).First();
+
+        FailingPutReplicaFilter.OfflinePartition = offline;
+
+        var grain = _cluster!.GrainFactory.GetGrain<IPartitionGrain>(primary);
+        Assert.ThrowsAsync<Exception>(() => grain.PutAsync(key, data));
+
+        FailingPutReplicaFilter.OfflinePartition = null;
+
+        var offlineGrain = _cluster.GrainFactory.GetGrain<IPartitionGrain>(offline);
+        var repaired = await offlineGrain.GetAsync(key);
+        Assert.That(repaired, Is.EqualTo(data));
+
+        var stored = await offlineGrain.GetReplicaAsync(key);
+        Assert.That(stored, Is.EqualTo(data));
+    }
+
+    [Test]
+    public async Task PutAsync_concurrent_calls_consistent()
+    {
+        var key1 = "concurrent1";
+        var data1 = new byte[] { 1 };
+        var replicas1 = _provider!.GetReplicas(key1).ToArray();
+        var primary = replicas1.First();
+
+        var key2 = "concurrent2";
+        while (_provider.GetReplicas(key2).First() != primary)
+        {
+            key2 += "x";
+        }
+
+        var data2 = new byte[] { 2 };
+        var replicas2 = _provider.GetReplicas(key2).ToArray();
+
+        var grain = _cluster!.GrainFactory.GetGrain<IPartitionGrain>(primary);
+
+        await Task.WhenAll(grain.PutAsync(key1, data1), grain.PutAsync(key2, data2));
+
+        foreach (var r in replicas1)
+        {
+            var g = _cluster.GrainFactory.GetGrain<IPartitionGrain>(r);
+            var stored = await g.GetReplicaAsync(key1);
+            Assert.That(stored, Is.EqualTo(data1));
+        }
+
+        foreach (var r in replicas2)
+        {
+            var g = _cluster.GrainFactory.GetGrain<IPartitionGrain>(r);
+            var stored = await g.GetReplicaAsync(key2);
+            Assert.That(stored, Is.EqualTo(data2));
+        }
+    }
+
+    [Test]
+    public async Task PutAsync_handles_membership_change()
+    {
+        var key = "membership-key";
+        var data = new byte[] { 7 };
+        var replicas = _provider!.GetReplicas(key).ToArray();
+        var primary = replicas.First();
+
+        var grain = _cluster!.GrainFactory.GetGrain<IPartitionGrain>(primary);
+        var putTask = grain.PutAsync(key, data);
+        _cluster.StartAdditionalSilo();
+        try
+        {
+            await putTask;
+            Assert.Fail("Expected timeout");
+        }
+        catch (TimeoutException)
+        {
+            // expected
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add failing call filter and expand test cluster for advanced scenarios
- test read repair when a replica is offline during writes
- cover concurrent writes and membership changes

## Testing
- `dotnet test Src/Nemcache.Tests/Nemcache.Tests.csproj`
- `dotnet test Src/Nemcache.DynamoService.Tests/Nemcache.DynamoService.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a8e3aa2a908327b9560e9c7748d839