### PR TITLE
Inject deterministic Random into RandomEvictionStrategy

### DIFF
--- a/Src/Nemcache.Storage/Eviction/RandomEvictionStrategy.cs
+++ b/Src/Nemcache.Storage/Eviction/RandomEvictionStrategy.cs
@@ -6,11 +6,12 @@ namespace Nemcache.Storage.Eviction
     public class RandomEvictionStrategy : IEvictionStrategy
     {
         private readonly IMemCache _cache;
-        private readonly Random _rng = new Random();
+        private readonly Random _rng;
 
-        public RandomEvictionStrategy(IMemCache cache)
+        public RandomEvictionStrategy(IMemCache cache, Random rng = null)
         {
             _cache = cache;
+            _rng = rng ?? new Random();
         }
 
         public void EvictEntry()


### PR DESCRIPTION
## Summary
- allow injecting a `Random` instance into `RandomEvictionStrategy`
- update tests to pass `Random` explicitly and use seeded RNGs
- add a test verifying deterministic eviction order for a fixed seed

## Testing
- `dotnet test Src/Nemcache.Tests/Nemcache.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a8e9a7a6dc83279a6f6edaee808479