### PR TITLE
Fix RandomEvictionTests syntax and complete test case

### DIFF
--- a/Src/Nemcache.Tests/Eviction/RandomEvictionTests.cs
+++ b/Src/Nemcache.Tests/Eviction/RandomEvictionTests.cs
@@ -85,7 +85,9 @@ namespace Nemcache.Tests.Eviction
             {
                 Assert.That(count, Is.InRange(250, 400));
             }
+        }
 
+        [Test]
         public void EvictRepeatedlyRemovesAllOriginalKeysInDeterministicOrder()
         {
             var memCache = new MemCache(100);


### PR DESCRIPTION
## Summary
- close RandomEvictionTests.EvictsFairlyOverManyRuns and restore missing [Test] on subsequent method
- ensure RandomEvictionTests compile and run successfully

## Testing
- `dotnet test Src/Nemcache.Tests/Nemcache.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68a8f22bb5b08327bf4b03f8228b96d9